### PR TITLE
Add description of have_ipv4_address matcher of interface type.

### DIFF
--- a/_includes/interface.md
+++ b/_includes/interface.md
@@ -9,3 +9,14 @@ describe interface('eth0') do
   its(:speed) { should eq 1000 }
 end
 ```
+
+#### have\_ipv4\_address
+
+In order to test a interface has a ip address, you should use **have\_ipv4\_address** matcher.
+
+```ruby
+describe interface('eth0') do
+  it { should have_ipv4_address("192.168.10.10") }
+  it { should have_ipv4_address("192.168.10.10/24") }
+end
+```


### PR DESCRIPTION
Add description of `have_ipv4_address` matcher of interface type.
Implementation of `have_ipv4_address` is here: serverspec/serverspec#228
