### PR TITLE
Use "spec" as the main task name instead of "serverspec"

### DIFF
--- a/advanced_tips.md
+++ b/advanced_tips.md
@@ -75,7 +75,7 @@ hosts = hosts.map do |host|
 end
  
 desc "Run serverspec to all hosts"
-task :serverspec => 'serverspec:all'
+task :spec => 'serverspec:all'
 
 class ServerspecTask < RSpec::Core::RakeTask
 
@@ -149,7 +149,7 @@ require 'yaml'
 properties = YAML.load_file('properties.yml')
  
 desc "Run serverspec to all hosts"
-task :serverspec => 'serverspec:all'
+task :spec => 'serverspec:all'
  
 namespace :serverspec do
   task :all => properties.keys.map {|key| 'serverspec:' + key.split('.')[0] }


### PR DESCRIPTION
This is more consistent with what is proposed by `serverspec-init` and
what is contained in the documentation. See: https://github.com/serverspec/serverspec/issues/328
