### PR TITLE
use its(:content) at a sample matcher

### DIFF
--- a/index.md
+++ b/index.md
@@ -76,7 +76,7 @@ end
 
 describe file('/etc/httpd/conf/httpd.conf') do
   it { should be_file }
-  it { should contain "ServerName www.example.jp" }
+  its(:content) { should match /ServerName www.example.jp/ }
 end
 ```
 


### PR DESCRIPTION
it uses `its(:content)` instead of `contain`.
 http://serverspec.org/resource_types.html#file
see https://github.com/serverspec/serverspec/pull/347
