### PR TITLE
follow PPA resource type description.

### DIFF
--- a/_includes/ppa.md
+++ b/_includes/ppa.md
@@ -6,7 +6,7 @@ PPA resource type.
 
 In order to test a given ppa repository exists,  you should use **exist** matcher.
 
-You can specify ppa name which is got rid of `ppa:`.
+PPA resource type accepts both `ppa:username/reponame` and `username/reponame` style.
 
 ```ruby
 describe ppa('launchpad-username/ppa-name') do


### PR DESCRIPTION
Follow PPA resource type change.
By https://github.com/serverspec/specinfra/pull/121, PPA resouce type
can accept both `ppa:username/reponame` and `username/reponame` style.
