### PR TITLE
Make Resource Types sticky past breakpoint

### DIFF
--- a/resource_types.md
+++ b/resource_types.md
@@ -3,9 +3,22 @@ layout: layout
 title: Resource Types
 ---
 
+<script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+<script>
+  $(document).ready(function() {
+    var resource_types = $('nav.resource-types');
+
+    $(document).on('scroll', function (event) {
+      console.log(event);
+      var past_breakpoint = $(this).scrollTop() > 443
+      resource_types.toggleClass("fixed-resource-types", past_breakpoint);
+    });
+  });
+</script>
+
 ## Resource Types
 
-<nav>
+<nav class="resource-types">
   [cgroup](#cgroup)
 | [command](#command)
 | [cron](#cron)

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -367,7 +367,16 @@ Full-Width Styles
   background: #212121;
 }
 
+.resource-types {
+  background: white;
+  padding: 1em;
+  width: 1140px;
+}
 
+.fixed-resource-types {
+  position: fixed;
+  top: 0;
+}
 
 /*******************************************************************************
 Small Device Styles


### PR DESCRIPTION
I'd love if the Resource Types documentation had a persistent navigation so I don't have to scroll to the top to look at the documentation for another resource. Here's my best attempt.

![screenshot](http://f.cl.ly/items/2J04233P3Z251R3q2S3l/Screen%20Shot%202014-07-15%20at%2010.18.33%20AM.png)

Two bugs that are beyond my UI skills:
- Page pops up when header becomes fixed. Solvable with an empty fixed-height element?
- Headers are hidden when navigating to them. We could make a different anchor for it to scroll to, but I didn't want to modify every doc page. See http://nicolasgallagher.com/jump-links-and-viewport-positioning/demo/#method-D.
