### PR TITLE
Uniform html tag for 'matcher'

### DIFF
--- a/_includes/bridge.md
+++ b/_includes/bridge.md
@@ -2,7 +2,7 @@
 
 Network bridge resource type.
 
-### exist
+#### exist
 
 In order to test a bridge exists, you shoud use **exist** matcher.
 

--- a/_includes/interface.md
+++ b/_includes/interface.md
@@ -2,7 +2,7 @@
 
 Network interface resource type.
 
-### exist
+#### exist
 
 In order to test a interface exist, you shoud use **exist** matcher.
 

--- a/_includes/selinux.md
+++ b/_includes/selinux.md
@@ -2,7 +2,7 @@
 
 SELinux resource type.
 
-#### be\_disabled/be\_enforcing/be\_permissive
+#### be\_disabled, be\_enforcing, be\_permissive
 
 In order to test SELinux is a given mode, you should use **be\_disabled, be\_enforcing and be\_permissive** matchers.
 


### PR DESCRIPTION
This PR is tiny fix.....

I just noticed this, when I exec following command to generate https://github.com/k1LoW/emacs-serverspec/blob/master/dict/serverspec 

```
$ curl http://serverspec.org/resource_types.html | grep h4 | sed 's/<\/*h4>//g' | sort | uniq
```