### PR TITLE
fix markdown italics for x509 stuff

### DIFF
--- a/_includes/x509_certificate.md
+++ b/_includes/x509_certificate.md
@@ -22,9 +22,9 @@ describe x509_certificate('some_cert.pem') do
 end
 ```
 
-#### validity_in_days
+#### validity\_in\_days
 
-In order to ensure that a certificate is valid for a certain amount of days, use **validity_in_days**.
+In order to ensure that a certificate is valid for a certain amount of days, use **validity\_in\_days**.
 
 ```ruby
 describe x509_certificate('some_cert.pem') do

--- a/_includes/x509_private_key.md
+++ b/_includes/x509_private_key.md
@@ -1,6 +1,6 @@
-### <a name="x509_private_key">x509_private_key</a>
+### <a name="x509_private_key">x509\_private\_key</a>
 
-x509_private_key resource type
+x509\_private\_key resource type
 
 #### be_encrypted
 
@@ -22,7 +22,7 @@ describe x509_private_key('/my/private/server-key.pem') do
 end
 ```
 
-#### has_matching_certificate
+#### has\_matching\_certificate
 
 In order to ensure that the private key modulus is equal to modulus of given certificate, that is, certificate has been created from key. 
 


### PR DESCRIPTION
Markdown turned _.._ into italics, preview on gh was ok but on the website its interpreted differently. 