### PR TITLE
Add usage of sudo_options to advanced tips

### DIFF
--- a/advanced_tips.md
+++ b/advanced_tips.md
@@ -312,6 +312,28 @@ end
 
 ----
 
+You can pass specific options to sudo.
+
+For example, run command under `appuser` with simulate initial login.
+
+```ruby
+# In spec_helper.rb
+set :sudo_options, [ '-u', 'appuser', '-i' ]  # By Array
+or
+set :sudo_options, '-u appuser -i'  # By String
+```
+
+Or only in a block scope.
+
+```ruby
+describe command('~/.rbenv/shims/gem list') do
+  let(:sudo_options) { '-u appuser -i' }
+  its(:stdout) { should contain('bundler') }
+end
+```
+
+----
+
 ## How to get OS information
 
 You can get OS information of the target host by `os` helper method.


### PR DESCRIPTION
sudo_optionsの指定が便利でしたがTipsになかったので。

こちらの実装を参考にしました。
https://github.com/serverspec/specinfra/blob/master/lib/specinfra/backend/ssh.rb#L159-L163