### PR TITLE
Fixes a few advanced_tips items for clarity

### DIFF
--- a/advanced_tips.md
+++ b/advanced_tips.md
@@ -102,7 +102,7 @@ mkdir -p serverspec/shared/database
 then serverspec/shared/database/init.rb:
 
 ```ruby
-shared_examples 'db::init' do
+shared_examples 'database::init' do
 
   describe package('mysql-community-server') do
     it { should be_installed }
@@ -128,7 +128,7 @@ and maybe bacon.bar.com also has apache:
 ```ruby
 require 'spec_helper'
 
-describe 'foo.bar.com' do
+describe 'bacon.bar.com' do
   include_examples 'database::init'
   include_examples 'apache::init'
 end


### PR DESCRIPTION
Noticed a few items in the code examples for the `shared_examples` section that don't line with the each other or the descriptions.