### PR TITLE
Typo fixes

### DIFF
--- a/_includes/port.md
+++ b/_includes/port.md
@@ -33,7 +33,7 @@ describe port(53) do
 end
 ```
 
-You can specificy local binding address for port (this features requires `gem 'serverspec', '~> 2.0.0.beta8'`).
+You can specify local binding address for port (this features requires `gem 'serverspec', '~> 2.0.0.beta8'`).
 
 ```ruby
 describe port(80) do

--- a/_includes/selinux.md
+++ b/_includes/selinux.md
@@ -4,7 +4,7 @@ SELinux resource type.
 
 #### be\_disabled, be\_enforcing, be\_permissive
 
-In order to test SELinux is a given mode, you should use **be\_disabled, be\_enforcing and be\_permissive** matchers.
+In order to test SELinux is running in a given mode, you should use **be\_disabled, be\_enforcing and be\_permissive** matchers.
 
 ```ruby
 # SELinux should be disabled

--- a/_includes/x509_certificate.md
+++ b/_includes/x509_certificate.md
@@ -4,7 +4,7 @@ x509_certificate resource type
 
 #### be_certificate
 
-In order to check wether a file is a certificate, use **be_certificate** matcher.
+In order to check whether a file is a certificate, use **be_certificate** matcher.
 
 ```ruby
 describe x509_certificate('some_cert.pem') do


### PR DESCRIPTION
Just some minor typo fixes for `_includes/x509_certificate.md`, `_includes/port.md` and `_includes/selinux.md`.