### PR TITLE
Removed wrapping HTML element, moved markdown to be consistent with other pages

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -3,13 +3,13 @@ layout: layout
 title: tutorial
 ---
 
-<nav>
+## Tutorial
+
   [Writing tests](#writing_tests)
 | [Multi OS support](#multi_os_support)
 | [Sudo password support](#sudo_password_support)
-</nav>
 
-## Tutorial
+----
 
 ### <a name="writing_tests">Writing tests</a>
 


### PR DESCRIPTION
Menu isn't being rendered due to the wrapping HTML element (http://serverspec.org/tutorial.html)

I've edited the page to be consistent with the *Resource Types* page.