### PR TITLE
Fix pattern matching string

### DIFF
--- a/advanced_tips.md
+++ b/advanced_tips.md
@@ -76,7 +76,7 @@ namespace :spec do
     desc "Run serverspec to #{host}"
     RSpec::Core::RakeTask.new(short_name) do |t|
       ENV['TARGET_HOST'] = host
-      t.pattern = "spec/base,#{role}/*_spec.rb"
+      t.pattern = "spec/{base,#{role}}/*_spec.rb"
     end
   end
 end


### PR DESCRIPTION
:red_circle: With actual pattern, rspec goes like this : 
```bash
rspec --pattern spec/base,myrole/\*_spec.rb
```
So it is searching for a folder named `base,myrole`

 :white_check_mark:  Whith the fix, rspec goes like : 
```bash
rspec --pattern spec/{base,myrole}/\*_spec.rb
```
So it is searching for folders `base` and `myrole`