### PR TITLE
Adding :count attribute matcher to type process

### DIFF
--- a/_includes/process.md
+++ b/_includes/process.md
@@ -15,6 +15,16 @@ For the complete list of available parameters, check the manual page
 for `ps(1)`, section _Standard Format Specifiers_. When several
 processes match, only the parameters of the first one are available.
 
+#### count
+
+To check the number of processes running under a given name use the **count** attribute matcher. 
+
+```ruby
+describe process("rsyslogd") do
+  its(:count) { should eq 1 }
+end
+```
+
 #### be_running
 
 To check if a given process is running, you should use **be_running** matcher.


### PR DESCRIPTION
Found an undocumented attribute matcher in the process type.