### PR TITLE
its(:ipv4/v6_address) feature in interface resource documentation

### DIFF
--- a/_includes/interface.md
+++ b/_includes/interface.md
@@ -52,3 +52,31 @@ describe interface('eth0') do
   it { should have_ipv6_address("fd00::1/48") }
 end
 ```
+
+#### its(:ipv4_address)
+
+Query the IPv4 ipaddress of an interface and apply any rspec supported matchers.
+
+```ruby
+describe interface('eth0') do
+  its(:ipv4_address) { should eq '1.2.3.4/1' }
+end
+
+describe interface('eth0') do
+  its(:ipv4_address) { should match /1\.2\.3\./ }
+end
+```
+
+#### its(:ipv6_address)
+
+Query the IPv6 ipaddress of an interface and apply any rspec supported matchers.
+
+```ruby
+describe interface('eth0') do
+  its(:ipv6_address) { should eq '2001:db8::1234/1' }
+end
+
+describe interface('eth0') do
+  its(:ipv6_address) { should match /2001:db8:.*/ }
+end
+```


### PR DESCRIPTION
Updating documentation for mizzy/serverspec#559.