### PR TITLE
Updates docker_container resource documentation to describe the have_…

### DIFF
--- a/_includes/docker_container.md
+++ b/_includes/docker_container.md
@@ -37,6 +37,7 @@ In order to test if a volume has been mounted.
 
 ```ruby
 describe docker_container('focused_curie') do
+  # matcher syntax: have_volume(container_path,host_path)
   it { should have_volume('/tmp','/data') }
 end
 ```


### PR DESCRIPTION
…volume matcher's syntax since it is the reverse parameter order you would expect.

All docker commands take volume mounts as `host_path:container_path` and since serverspec's matcher is reversed it was not intuitive to determine the cause of test failures. This note may help future test writers from making the same mistake.

Reference: https://github.com/mizzy/serverspec/blob/master/lib/serverspec/type/docker_container.rb#L7