### PR TITLE
Documentation improvements

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -58,7 +58,7 @@
     <div id="footer_wrap" class="outer">
       <footer class="inner">
         <p>This project is maintained by <a href="http://mizzy.org/">Gosuke Miyashita</a></p>
-        <p>Published with <a href="http://pages.github.com">GitHub Pages</a></p>
+        <p>Published with <a href="http://pages.github.com">GitHub Pages</a> (<a href="https://github.com/serverspec/serverspec.github.io">documentation repository</a>)</p>
       </footer>
     </div>
 

--- a/advanced_tips.md
+++ b/advanced_tips.md
@@ -134,7 +134,23 @@ describe 'bacon.bar.com' do
 end
 ```
 
-You can see examples in [rubyisbeautiful/serverspec_examples](https://github.com/rubyisbeautiful/serverspec_examples)
+Note that you can also pass parameters for greater reuse:
+
+```ruby
+shared_examples 'deploy_user' do |deploy_user|
+  describe user(deploy_user) do
+    it { should exist }
+    it { should have_home_directory("/home/#{deploy_user}") }
+  end
+end
+
+# then later
+include_examples 'deploy_user', 'the_user'
+```
+
+You can see examples in [rubyisbeautiful/serverspec_examples](https://github.com/rubyisbeautiful/serverspec_examples).
+
+[RSpec shared examples docs](https://www.relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples) will also help.
 
 ----
 


### PR DESCRIPTION
In this PR:

* Documentation for shared examples parameters, which come handy to improve reuse. I thought it was worth documenting, because it wasn't immediate to understand these are actually a direct use of RSpec shared examples.
* A link to the documentation repository (because it took me quite some time to figure out where it was).

As a meta-note, I had issues rendering the site locally (some unclear trouble with redcarpet). Updating `gh-pages` and removing `markdown: redcarpet` solved the issue for me.